### PR TITLE
Fix case of duplicate column names in deconstruct

### DIFF
--- a/src/Strapping.jl
+++ b/src/Strapping.jl
@@ -406,6 +406,9 @@ function deconstruct(values::Vector{T}) where {T}
     x = values[1]
     StructTypes.foreachfield(c, x)
     len = c.len
+    names = copy(c.names)
+    types = copy(c.types)
+    fieldindices = copy(c.fieldindices)
     lens = [len]
     for i = 2:length(values)
         c.len = 1
@@ -413,9 +416,8 @@ function deconstruct(values::Vector{T}) where {T}
         len += c.len
         push!(lens, c.len)
     end
-    names = c.names
     lookup = Dict(nm => i for (i, nm) in enumerate(names))
-    return DeconstructedRowsIterator(values, lens, len, names, c.types, c.fieldindices, lookup)
+    return DeconstructedRowsIterator(values, lens, len, names, types, fieldindices, lookup)
 end
 
 Base.eltype(x::DeconstructedRowsIterator{T}) where {T} = DeconstructedRow{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,10 +129,6 @@ struct TestStruct
     id::Int
 end
 
-function TestStruct(a,b,id)
-    TestStruct(a,b,id)
-end
-
 StructTypes.StructType(::Type{TestStruct}) = StructTypes.Struct()
 StructTypes.idproperty(::Type{TestStruct}) = :id
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,3 +121,22 @@ ab6 = AB6(1, [3.14, 3.15, 3.16], AB(2, 0.01), [AB(10, 1.1), AB(11, 2.2), AB(12, 
 @test Strapping.construct(AB6, tbl6) == ab6
 @test Strapping.construct(Vector{AB6}, tbl6) == [ab6]
 @test columntable(Strapping.deconstruct(ab6)) == tbl6
+
+# https://github.com/JuliaData/Strapping.jl/issues/3
+struct TestStruct
+    a::Float64
+    b::Float64
+    id::Int
+end
+
+function TestStruct(a,b,id)
+    TestStruct(a,b,id)
+end
+
+StructTypes.StructType(::Type{TestStruct}) = StructTypes.Struct()
+StructTypes.idproperty(::Type{TestStruct}) = :id
+
+data = [ TestStruct(rand(2)..., n) for n = 1:5]
+
+tbl = Strapping.deconstruct(data)
+@test length(Tables.columntable(tbl)[1]) == 5


### PR DESCRIPTION
Fixes #3. The issue here was that after detecting the final column names
and types from the first element of a `Vector{T}`, we then passed those
names/types vectors to subsequent elements and they appended the same
names/types again. So we ended up with names * N and types * N, where N
is the number of elements in the original `Vector{T}`. The fix is pretty
easy: after we process the first element, save the names/types and use
those in the final DeconstructedRowIterator.