### PR TITLE
Support StructTypes.DictType when deconstructing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,3 +136,17 @@ data = [ TestStruct(rand(2)..., n) for n = 1:5]
 
 tbl = Strapping.deconstruct(data)
 @test length(Tables.columntable(tbl)[1]) == 5
+
+struct AA1
+    a::Int64
+    b::Dict{Symbol, Any}
+end
+
+StructTypes.StructType(::Type{AA1}) = StructTypes.Struct()
+
+data = [ AA1(1, Dict{Symbol, Any}(:aa => 2, :bb => 3)) ]
+tbl = Strapping.deconstruct(data)
+tbl2 = Tables.columntable(tbl)
+@test tbl2.a == [1]
+@test tbl2.b_aa == [2]
+@test tbl2.b_bb == [3]


### PR DESCRIPTION
Fixes #6. I can't quite remember why, but when `Strapping.deconstruct` was introduced, no support for `StructTypes.DictType` was available. If I had to guess, I probably just thought it was too hard at the time. It turns out that's not too bad, other than that we have to keep track of field names and sub-field names alongside the field indices and sub-field indices we were already tracking when deconstructing.

There are a few other related changes here not totally essential to the core of supporting DictType, but which make deconstructing more robust. We get rid of `Tables.schema`, since it can be tricky if different elements we're deconstructing end up having a field of one type or another. By removing `Tables.schema`, we let sinks "figure it out" when they pull the data through; this can often lead to better inferred column types in the sinks. We also just used the first deconstructed element to determine column names, including normalized nested fields. I'm a little torn on this, because I know sometimes people hope to have a "unioning" behavior when processing lists of values like this, so in case later elements add new fields or don't include null fields at all, for example, things still work. I do think we should support that, and there's code we can mirror already available in JSONTables.jl, which provides that functionality, but doesn't include support for subfield normalization. For now, we just use the first deconstructed element to get the column names that each subsequent element should also support (i.e. homogenous schema-ed objects).