### PR TITLE
Refactor Strapping.construct to properly recurse

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,9 +59,9 @@ end
 
 StructTypes.StructType(::Type{AB3}) = StructTypes.Struct()
 
-tbl3 = (a=[10], ab_a=[10], ab_b=[3.14])
+tbl3 = (a=[1], ab_a=[10], ab_b=[3.14])
 
-ab3 = AB3(10, AB(10, 3.14))
+ab3 = AB3(1, AB(10, 3.14))
 @test Strapping.construct(AB3, tbl3) == ab3
 @test Strapping.construct(Vector{AB3}, tbl3) == [ab3]
 
@@ -150,3 +150,30 @@ tbl2 = Tables.columntable(tbl)
 @test tbl2.a == [1]
 @test tbl2.b_aa == [2]
 @test tbl2.b_bb == [3]
+
+#8
+struct TestResult
+    id::Int
+    values::Vector{Float64}
+end
+StructTypes.StructType(::Type{TestResult}) = StructTypes.Struct()
+StructTypes.idproperty(::Type{TestResult}) = :id
+
+tbl = (id=[1, 1, 1, 2, 2, 2], values=[3.14, 3.15, 3.16, 40.1, 0.01, 2.34])
+testresult = Strapping.construct(Vector{TestResult}, tbl)
+
+struct Experiment
+    id::Int
+    name::String
+    testresults::TestResult
+end
+StructTypes.StructType(::Type{Experiment}) = StructTypes.Struct()
+StructTypes.idproperty(::Type{Experiment}) = :id
+
+StructTypes.fieldprefix(::Type{Experiment}, nm::Symbol) = nm == :testresults ? :testresults_ : :_
+
+tbl2 = (id=[1, 1, 1], name=["exp1", "exp1", "exp1"], testresults_id=[1, 1, 1], testresults_values=[3.14, 3.15, 3.16])
+experiment = Strapping.construct(Experiment, tbl2)
+@test experiment.id == 1
+@test experiment.name == "exp1"
+@test experiment.testresults.values == [3.14, 3.15, 3.16]


### PR DESCRIPTION
Fixes #8. I think the example in the issue originally worked, but may have gotten broken w/ a fix at some point. Going back over this code was a little tricky though since it's been a while. I basically started from scratch and built up the code again, which was a good exercise in simplifying a lot of the structure. At least locally, all tests pass plus the addition of the example from the docs, so I think this is a pretty good net improvement. The core issue was that in the old code, we weren't properly recursing in the construct methods for aggregates in the case of nested aggregates.

I'll also note for posterity that I looked into the possibility of supporting nested DictType, but I just don't think it makes a lot of sense fundamentally. The DictType is really about "slurping" all available fields into a Dict-like struct instead of the Struct/Mutable case where we know the fields that we're pulling out of the incoming table rows. I do think it could be possible for us to allow returning a Dict{IdFieldType, T} from the top-level construct instead of Vector{T} in the case of multiple return elements. Sometimes it can be handy to get the Dict back instead of the Vector{T} and then needing to key-value map that into a Dict. This would work by using the idproperty property of a struct as the Dict key entries.