### PR TITLE
Refactor Strapping.deconstruct for robustness and several fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 [compat]
 julia = "1"
 Tables = "1"
-StructTypes = "1"
+StructTypes = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Strapping.jl
+++ b/src/Strapping.jl
@@ -321,11 +321,52 @@ end
     Strapping.deconstruct(x::T)
     Strapping.deconstruct(x::Vector{T})
 
-The inverse of `Strapping.construct`, where an object instance `x::T` or `Vector` of objects `x::Vector{T}` is "deconstructed" into a Tables.jl-compatible row iterator. This works following the same patterns outlined in `Strapping.construct` with regards to `ArrayType` and aggregate fields. Specifically, `ArrayType` fields will cause multiple rows to be outputted, one row per collection element, with other scalar fields being repeated in each row. Similarly for aggregate fields, the field prefix will be used (`StructTypes.fieldprefix`) and nested aggregates will all be flattened into a single list of column names with aggregate prefixes.
+The inverse of `Strapping.construct`, where an object instance `x::T` or `Vector` of objects `x::Vector{T}` is "deconstructed" into a Tables.jl-compatible row iterator. This works following the same patterns outlined in `Strapping.construct` with regards to `ArrayType` and aggregate fields. Specifically, `ArrayType` fields will cause multiple rows to be outputted, one row per collection element, with other scalar fields being repeated in each row. Note this requires no more than one collection field, since otherwise it's ambiguous on how to repeat rows. Similarly for aggregate fields, the field prefix will be used (`StructTypes.fieldprefix`) and nested aggregates will all be flattened into a single list of column names with aggregate prefixes.
 
-In general, this allows outputting any "object" as a 2D table structure that could be stored in any Tables.jl-compatible sink format, e.g. csv file, sqlite table, mysql database table, feather file, etc.
+In general, this allows outputting any "object" as a 2D table structure that could be stored in any Tables.jl-compatible sink format, e.g. csv file, sqlite table, mysql database table, arrow file, etc.
+
+Note that currently the code requires collection fields to be indexable (i.e. supports `getindex` and `length`) as well as 
+to have `eltype` defined. Also note that if any collection fields are empty, it will result in the output columns having `Union{T, Missing}`
+types since the non-collection fields will still be output as a single row, with collection field(s) being `missing`.
 """
 function deconstruct end
+
+mutable struct FieldNode
+    index::Int
+    name::Symbol
+    subfield::Union{FieldNode, Nothing}
+end
+
+Base.copy(x::FieldNode) = FieldNode(x.index, x.name, x.subfield === nothing ? nothing : copy(x.subfield))
+
+# recurse until find empty subfield and set `sub`
+function setsubfield!(fn::FieldNode, sub::FieldNode)
+    if fn.subfield === nothing
+        fn.subfield = sub
+    else
+        setsubfield!(fn.subfield, sub)
+    end
+    return
+end
+
+getfieldvalue(x::T, ind, fn) where {T} = getfieldvalue(StructTypes.StructType(T), x, ind, fn)
+
+function getfieldvalue(::StructTypes.DictType, x, ind, fn)
+    val = x[fn.name]
+    return getfieldvalue(val, ind, fn.subfield)
+end
+
+getfieldvalue(::StructTypes.ArrayType, x, ind, fn) = isempty(x) ? missing : getfieldvalue(x[ind], 0, fn)
+
+function getfieldvalue(::Union{StructTypes.Struct, StructTypes.Mutable}, x, ind, fn)
+    val = Core.getfield(x, fn.index)
+    return getfieldvalue(val, ind, fn.subfield)
+end
+
+function getfieldvalue(ST, x, ind, fn)
+    @assert fn === nothing
+    return x
+end
 
 # single object or vector => Tables.rows iterator
 struct DeconstructedRowsIterator{T, A}
@@ -334,111 +375,8 @@ struct DeconstructedRowsIterator{T, A}
     len::Int
     names::Vector{Symbol}
     types::Vector{Type}
-    fieldindices::Vector{Tuple{Int, Int}}
-    fieldnames::Vector{Tuple{Symbol, Symbol}}
+    fields::Vector{FieldNode}
     lookup::Dict{Symbol, Int}
-end
-
-Tables.isrowtable(::Type{<:DeconstructedRowsIterator}) = true
-
-# disabled because 
-# Tables.schema(x::DeconstructedRowsIterator) = Tables.Schema(x.names, x.types)
-
-struct DeconstructedRow{T} <: Tables.AbstractRow
-    x::T # a single object we're deconstructing
-    index::Int # index of this specific row (may be > 1 for objects w/ collection fields)
-    names::Vector{Symbol}
-    fieldindices::Vector{Tuple{Int, Int}}
-    fieldnames::Vector{Tuple{Symbol, Symbol}}
-    lookup::Dict{Symbol, Int}
-end
-
-obj(x::DeconstructedRow) = getfield(x, :x)
-ind(x::DeconstructedRow) = getfield(x, :index)
-names(x::DeconstructedRow) = getfield(x, :names)
-inds(x::DeconstructedRow) = getfield(x, :fieldindices)
-nms(x::DeconstructedRow) = getfield(x, :fieldnames)
-lookup(x::DeconstructedRow) = getfield(x, :lookup)
-
-Tables.columnnames(row::DeconstructedRow) = names(row)
-Tables.getcolumn(row::DeconstructedRow, ::Type{T}, i::Int, nm::Symbol) where {T} =
-    getfieldvalue(obj(row), ind(row), inds(row)[i], nms(row)[i])
-Tables.getcolumn(row::DeconstructedRow, i::Int) =
-    getfieldvalue(obj(row), ind(row), inds(row)[i], nms(row)[i])
-Tables.getcolumn(row::DeconstructedRow, nm::Symbol) = Tables.getcolumn(row, lookup(row)[nm])
-
-mutable struct DeconstructClosure{PT}
-    len::Int
-    names::Vector{Symbol}
-    types::Vector{Type}
-    fieldindices::Vector{Tuple{Int, Int}}
-    fieldnames::Vector{Tuple{Symbol, Symbol}}
-    parentindex::Int
-    parentname::Symbol
-    prefix::Symbol
-    j::Int
-    nm::Symbol
-    parenttype::Type{PT}
-end
-
-DeconstructClosure(PT) = DeconstructClosure(1, Symbol[], Type[], Tuple{Int, Int}[], Tuple{Symbol, Symbol}[], 0, Symbol(), Symbol(), 1, Symbol(), PT)
-
-function (f::DeconstructClosure)(i, nm, TT, v; kw...)
-    len = valuelength(StructTypes.StructType(TT), v)
-    if len > f.len
-        f.len = len
-    end
-    nametypeindex!(v, i, nm, f)
-    return
-end
-
-mutable struct DeconstructLenClosure
-    len::Int
-end
-
-function (f::DeconstructLenClosure)(i, nm, TT, v; kw...)
-    len = valuelength(StructTypes.StructType(TT), v)
-    if len > f.len
-        f.len = len
-    end
-    return
-end
-
-deconstructobj!(x::T, c) where {T} = deconstructobj!(StructTypes.StructType(T), x, c)
-deconstructobj!(ST, x, c) = StructTypes.foreachfield(c, x)
-
-function deconstructobj!(::StructTypes.DictType, x, c)
-    i = 1
-    for (k, v) in StructTypes.keyvaluepairs(x)
-        c(i, k, typeof(v), v)
-        i += 1
-    end
-    return
-end
-
-deconstruct(x) = deconstruct([x])
-
-function deconstruct(values::A) where {T, A <: AbstractVector{T}}
-    c = DeconstructClosure(T)
-    flens = DeconstructLenClosure(0)
-    lens = Int[]
-    len = 0
-    i = 0
-    for x in values
-        if i == 0
-            deconstructobj!(x, c)
-            push!(lens, c.len)
-            len += c.len
-        else
-            flens.len = 0
-            deconstructobj!(x, flens)
-            len += flens.len
-            push!(lens, flens.len)
-        end
-        i += 1
-    end
-    lookup = Dict(nm => i for (i, nm) in enumerate(c.names))
-    return DeconstructedRowsIterator{T, A}(values, lens, len, c.names, c.types, c.fieldindices, c.fieldnames, lookup)
 end
 
 Base.eltype(x::DeconstructedRowsIterator{T}) where {T} = DeconstructedRow{T}
@@ -451,59 +389,187 @@ Base.length(x::DeconstructedRowsIterator) = x.len
 @inline function Base.iterate(x::DeconstructedRowsIterator, (i, j, k)=(1, 1, 1))
     k > x.len && return nothing
     if j == x.lens[i]
-        return DeconstructedRow(x.values[i], j, x.names, x.fieldindices, x.fieldnames, x.lookup), (i + 1, 1, k + 1)
+        return DeconstructedRow(x.values[i], j, x.names, x.fields, x.lookup), (i + 1, 1, k + 1)
     else
-        return DeconstructedRow(x.values[i], j, x.names, x.fieldindices, x.fieldnames, x.lookup), (i, j + 1, k + 1)
+        return DeconstructedRow(x.values[i], j, x.names, x.fields, x.lookup), (i, j + 1, k + 1)
     end
 end
 
-valuelength(ST, x) = 1
-valuelength(::StructTypes.ArrayType, x) = length(x)
+Tables.isrowtable(::Type{<:DeconstructedRowsIterator}) = true
+Tables.schema(x::DeconstructedRowsIterator) = Tables.Schema(x.names, x.types)
 
-getfieldvalue(x::T, ind, (i, j), (nm1, nm2)) where {T} = getfieldvalue(StructTypes.StructType(T), x, ind, (i, j), (nm1, nm2))
-getfieldvalue(ST, x, ind, (i, j), (nm1, nm2)) = x
-getfieldvalue(::StructTypes.ArrayType, x, ind, (i, j), (nm1, nm2)) = getfieldvalue(x[ind], ind, (i, j), (nm1, nm2))
-getfieldvalue(::Union{StructTypes.Struct, StructTypes.Mutable}, x, ind, (i, j), (nm1, nm2)) = getsubfieldvalue(Core.getfield(x, i), ind, (i, j), (nm1, nm2))
-getfieldvalue(::StructTypes.DictType, x, ind, (i, j), (nm1, nm2)) = getsubfieldvalue(x[nm1], ind, (i, j), (nm1, nm2))
-
-getsubfieldvalue(x::T, ind, (i, j), (nm1, nm2)) where {T} = getsubfieldvalue(StructTypes.StructType(T), x, ind, (i, j), (nm1, nm2))
-getsubfieldvalue(ST, x, ind, (i, j), (nm1, nm2)) = x
-getsubfieldvalue(::StructTypes.ArrayType, x, ind, (i, j), (nm1, nm2)) = getsubfieldvalue(x[ind], ind, (i, j), (nm1, nm2))
-getsubfieldvalue(::Union{StructTypes.Struct, StructTypes.Mutable}, x, ind, (i, j), (nm1, nm2)) = getsubfieldvalue(Core.getfield(x, j), ind, (i, j), (nm1, nm2))
-function getsubfieldvalue(::StructTypes.DictType, x, ind, (i, j), (nm1, nm2))
-    getsubfieldvalue(x[nm2], ind, (i, j), (nm1, nm2))
+struct DeconstructedRow{T} <: Tables.AbstractRow
+    x::T # a single object we're deconstructing
+    index::Int # index of this specific row (may be > 1 for objects w/ collection fields)
+    names::Vector{Symbol}
+    fields::Vector{FieldNode}
+    lookup::Dict{Symbol, Int}
 end
 
-rowtypeof(x::T) where {T} = rowtypeof(StructTypes.StructType(T), x)
-rowtypeof(::StructTypes.ArrayType, x) = eltype(x)
-rowtypeof(ST, x) = typeof(x)
+obj(x::DeconstructedRow) = getfield(x, :x)
+ind(x::DeconstructedRow) = getfield(x, :index)
+names(x::DeconstructedRow) = getfield(x, :names)
+fields(x::DeconstructedRow) = getfield(x, :fields)
+lookup(x::DeconstructedRow) = getfield(x, :lookup)
 
-nametypeindex!(x::T, i, nm, c) where {T} = nametypeindex!(StructTypes.StructType(T), x, i, nm, c)
+Tables.columnnames(row::DeconstructedRow) = names(row)
+Tables.getcolumn(row::DeconstructedRow, ::Type{T}, i::Int, nm::Symbol) where {T} =
+    getfieldvalue(obj(row), ind(row), fields(row)[i])
+Tables.getcolumn(row::DeconstructedRow, i::Int) =
+    getfieldvalue(obj(row), ind(row), fields(row)[i])
+Tables.getcolumn(row::DeconstructedRow, nm::Symbol) = Tables.getcolumn(row, lookup(row)[nm])
 
-function nametypeindex!(ST, x, i, nm, c)
-    push!(c.names, Symbol(c.prefix, nm))
-    push!(c.types, rowtypeof(x))
-    push!(c.fieldindices, (c.parentindex > 0 ? c.parentindex : i, c.j))
-    push!(c.fieldnames, (c.parentindex > 0 ? c.parentname : nm, nm))
-    c.j += 1
+mutable struct DeconstructClosure{}
+    len::Int
+    names::Vector{Symbol}
+    types::Vector{Type}
+    fields::Vector{FieldNode}
+    prefix::Symbol
+    fieldnode::Union{FieldNode, Nothing}
+    i::Int
+    processedArrayType::Bool
+    emptyArrayType::Bool
+    parentType::Type
+end
+
+DeconstructClosure() = DeconstructClosure(1, Symbol[], Type[], FieldNode[], Symbol(), nothing, 1, false, false, Any)
+
+# if we're direct root child, sub is full field ancestry (i.e. name/index are name/index of root object)
+# if we're further nested than direct root child,
+# we make a copy of the fieldnode ancestry and set
+# our new node as new leaf node
+function getfieldnode(f::DeconstructClosure, sub::FieldNode)
+    if f.fieldnode === nothing
+        return sub
+    else
+        fn = copy(f.fieldnode)
+        setsubfield!(fn, sub)
+        return fn
+    end
+end
+
+function reset!(f::DeconstructClosure)
+    f.i = 1
+    f.len = 1
+    f.processedArrayType = false
+    f.emptyArrayType = false
     return
 end
 
-function nametypeindex!(::Union{StructTypes.Struct, StructTypes.Mutable, StructTypes.DictType}, x::T, i, nm, c) where {T}
-    c2 = DeconstructClosure(T)
-    c2.names = c.names
-    c2.types = c.types
-    c2.fieldindices = c.fieldindices
-    c2.fieldnames = c.fieldnames
-    c2.parentindex = i
-    c2.parentname = nm
-    c2.prefix = Symbol(c.prefix, StructTypes.fieldprefix(c.parenttype, nm))
-    deconstructobj!(x, c2)
+(f::DeconstructClosure)(x::T) where {T} = f(StructTypes.StructType(T), x)
+
+struct EmptyArrayTypeValue end
+
+function (f::DeconstructClosure)(::Union{StructTypes.Struct, StructTypes.Mutable}, x::T) where {T}
+    # x is root object
+    reset!(f)
+    f.parentType = T
+    StructTypes.foreachfield(x) do i, nm, TT, v
+        # each root field is a separate prefix/fieldnode ancestry branch
+        f.prefix = Symbol()
+        f.fieldnode = nothing
+        f(i, nm, TT, v)
+    end
     return
 end
 
-function nametypeindex!(::StructTypes.ArrayType, x::T, i, nm, c) where {T}
-    nametypeindex!(x[1], i, nm, c)
+function (f::DeconstructClosure)(::StructTypes.DictType, x::T) where {T}
+    # x is root object
+    reset!(f)
+    f.parentType = T
+    i = 1
+    for (k, v) in StructTypes.keyvaluepairs(x)
+        # each root field is a separate prefix/fieldnode ancestry branch
+        f.prefix = Symbol()
+        f.fieldnode = nothing
+        f(i, k, typeof(v), v)
+        i += 1
+    end
+    return
+end
+
+(f::DeconstructClosure)(i, nm, TT, v; kw...) = f(StructTypes.StructType(TT), i, nm, TT, v)
+(f::DeconstructClosure)(i, nm, TT; kw...) = f(StructTypes.StructType(TT), i, nm, TT, EmptyArrayTypeValue())
+function (f::DeconstructClosure)(::Union{StructTypes.Struct, StructTypes.Mutable}, i, nm, TT, v)
+    f.prefix = Symbol(f.prefix, StructTypes.fieldprefix(f.parentType, nm))
+    f.parentType = TT
+    f.fieldnode = getfieldnode(f, FieldNode(i, nm, nothing))
+    StructTypes.foreachfield(f, v)
+    return
+end
+
+function (f::DeconstructClosure)(::Union{StructTypes.Struct, StructTypes.Mutable}, i, nm, TT, ::EmptyArrayTypeValue)
+    f.prefix = Symbol(f.prefix, StructTypes.fieldprefix(f.parentType, nm))
+    f.parentType = TT
+    f.fieldnode = getfieldnode(f, FieldNode(i, nm, nothing))
+    StructTypes.foreachfield(f, TT)
+    return
+end
+
+function (f::DeconstructClosure)(::StructTypes.DictType, i, nm, TT, x)
+    f.prefix = Symbol(f.prefix, StructTypes.fieldprefix(f.parentType, nm))
+    f.parentType = TT
+    f.fieldnode = getfieldnode(f, FieldNode(i, nm, nothing))
+    i = 1
+    for (k, v) in StructTypes.keyvaluepairs(x)
+        f(i, k, typeof(v), v)
+        i += 1
+    end
+    return
+end
+
+(f::DeconstructClosure)(::StructTypes.DictType, i, nm, TT, ::EmptyArrayTypeValue) =
+    error("unable to detect field types from empty StructTypes.ArrayType object with StructType.DictType eltype (since DictType keys/values are flattened each as fields and should always contain the same keys from element to element)")
+
+@noinline multiplearraytype(TT) = error("multiple StructTypes.ArrayType objects detected during Strapping.deconstruct; only one is allowed for determining repeated deconstructed rows; see StructTypes.excludes(T) = (:nm,) for excluding fields from deconstructing consideration")
+@noinline lengthrequired(T) = error("length(::$T) is required for Strapping.deconstruct")
+@noinline eltyperequired(T) = erorr("eltype($T) is required for Strapping.deconstruct")
+
+function (f::DeconstructClosure)(::StructTypes.ArrayType, i, nm, TT, v)
+    f.processedArrayType && multiplearraytype(TT)
+    f.processedArrayType = true
+    Base.haslength(v) || lengthrequired(TT)
+    f.len = max(1, length(v))
+    T = eltype(v)
+    st = iterate(v)
+    f.emptyArrayType = st === nothing
+    f(i, nm, T, st === nothing ? EmptyArrayTypeValue() : st[1])
+    return
+end
+
+function (f::DeconstructClosure)(ST, i, nm, TT, v)
+    if f.i > length(f.names)
+        # first time deconstructing obj
+        push!(f.names, Symbol(f.prefix, nm))
+        push!(f.types, f.emptyArrayType ? Union{Missing, TT} : TT)
+        push!(f.fields, getfieldnode(f, FieldNode(i, nm, nothing)))
+    else
+        # promote field type if needed
+        T = f.types[f.i]
+        TTT = promote_type(TT, T)
+        if !(TTT <: T)
+            f.types[f.i] = f.emptyArrayType ? Union{Missing, TTT} : TTT
+        end
+    end
+    f.i += 1
+    return
+end
+
+deconstruct(x) = deconstruct([x])
+
+function deconstruct(values::A) where {T, A <: AbstractVector{T}}
+    c = DeconstructClosure()
+    lens = Int[]
+    len = 0
+    i = 0
+    for x in values
+        c(x)
+        push!(lens, c.len)
+        len += c.len
+        i += 1
+    end
+    lookup = Dict(nm => i for (i, nm) in enumerate(c.names))
+    return DeconstructedRowsIterator{T, A}(values, lens, len, c.names, c.types, c.fields, lookup)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,21 +106,63 @@ ab5 = AB5(10, AB3(10, AB(10, 3.14)))
 
 struct AB6
     a::Int
-    b::Vector{Float64}
-    c::AB
-    d::Vector{AB}
+    b::AB
+    c::Vector{AB}
 end
 
-Base.:(==)(a::AB6, b::AB6) = a.a == b.a && a.b == b.b && a.c == b.c && a.d == b.d
+Base.:(==)(a::AB6, b::AB6) = a.a == b.a && a.b == b.b && a.c == b.c
 StructTypes.StructType(::Type{AB6}) = StructTypes.Struct()
 StructTypes.idproperty(::Type{AB6}) = :a
 
-tbl6 = (a=[1, 1, 1], b=[3.14, 3.15, 3.16], c_a=[2, 2, 2], c_b=[0.01, 0.01, 0.01], d_a=[10, 11, 12], d_b=[1.1, 2.2, 3.3])
+tbl6 = (a=[1, 1, 1], b_a=[2, 2, 2], b_b=[0.01, 0.01, 0.01], c_a=[10, 11, 12], c_b=[1.1, 2.2, 3.3])
 
-ab6 = AB6(1, [3.14, 3.15, 3.16], AB(2, 0.01), [AB(10, 1.1), AB(11, 2.2), AB(12, 3.3)])
+ab6 = AB6(1, AB(2, 0.01), [AB(10, 1.1), AB(11, 2.2), AB(12, 3.3)])
 @test Strapping.construct(AB6, tbl6) == ab6
 @test Strapping.construct(Vector{AB6}, tbl6) == [ab6]
 @test columntable(Strapping.deconstruct(ab6)) == tbl6
+
+# https://github.com/JuliaData/Strapping.jl/issues/12
+struct AB7
+    id::Int
+    values::Vector{Float64}
+end
+
+Base.:(==)(a::AB7, b::AB7) = a.id == b.id && a.values == b.values
+StructTypes.StructType(::Type{AB7}) = StructTypes.Struct()
+StructTypes.idproperty(::Type{AB7}) = :id
+
+ab7 = AB7(1, Float64[])
+tbl = columntable(Strapping.deconstruct(ab7))
+@test tbl.id[1] == 1
+@test tbl.values[1] === missing
+
+struct AB9
+    a::Int
+    b::String
+    c::Float64
+    d::String
+    e::Int
+    f::String
+end
+StructTypes.StructType(::Type{AB9}) = StructTypes.Struct()
+
+struct AB10
+    id::Int
+    ab9::AB9
+end
+StructTypes.StructType(::Type{AB10}) = StructTypes.Struct()
+
+struct AB11
+    id::Int
+    ab10::AB10
+end
+StructTypes.StructType(::Type{AB11}) = StructTypes.Struct()
+
+ab11 = AB11(1, AB10(2, AB9(3, "4", 5.0, "6", 7, "8")))
+tbl = columntable(Strapping.deconstruct(ab11))
+@test length(tbl) == 8
+@test tbl.id[1] == 1
+@test tbl[end][1] == "8"
 
 # https://github.com/JuliaData/Strapping.jl/issues/3
 struct TestStruct


### PR DESCRIPTION
Fixes #12. After a deep review of `Strapping.deconstruct` after the
recent revamp of `Strapping.construct`, I discovered there were a couple
of bad assumptions and hence, glaring bugs in the code. For example, the
code failed to actually take into account any nesting more than 2
levels, and if it worked, it was purely coincidental. There were also
some robustness issues in the output of `Strapping.deconstruct` column
types; the last time I touched the code, I removed `Tables.schema`
entirely, but that isn't very satisfying since we are looking at each
row, so we _should_ be able to figure out the right type for each
column. The code here fixes that, utilizing `promote_type` when
necessary. We also fix a bad assumption that any ArrayType
objects/fields would be non-empty. Now, empty ArrayTypes are a bit of an
oddity by themselves anyway, which is also further addressed here.
Notably, if empty ArrayTypes are encountered, their type(s) will become
`Union{T, Missing}`. Conceptually this is like taking the root object of
type `T` and knowing that in the usual case, we'll produce a single row
per object. In the case of collection fields, non-collection fields will
be repeated for each collection element, but if the collection field
itself is empty, we'll still produce a single row, but the collection
field(s) will produce `missing`.

That's a decent point to segue into another bigger idea I've had of
taking `Strapping.deconstruct` to an even more functional way of
normalizing where the presence of one or more collection fields would
result in an _iterator_ of output tables, one for the base
non-collection fields, and then one for each collection field. This
follows true normalization practices from the relational data world
where the primary object key would be the sole repeated key w/ each
collection field. We could then provide a way in `Strapping.construct`
to _provide_ multiple table inputs w/ an obvious or way to specify the
primary key and have all the collection fields processed appropriately.

Not exactly sure _how_ useful all that would be given the amount of
work, since there are lots of different workflows out there and styles
of using databases. If people think there are strong enough cases for
it, we can develop the idea further.